### PR TITLE
sed command seemed to trim a bit off the key in latest version of flux

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ At startup Flux generates a SSH key and logs the public key.
 Find the SSH public key with:
 
 ```bash
-kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2 | sed 's/.\{2\}$//'
+kubectl -n flux logs deployment/flux | grep identity.pub | cut -d '"' -f2
 ```
 
 In order to sync your cluster state with git you need to copy the public key and 


### PR DESCRIPTION
What is this MR for?

- the sed part of the command seemed to trim a bit of the key off for
me.