### PR TITLE
Update wiki with note about updating docker references and clarification on FluxHelmRelease location

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ helm init --skip-refresh --upgrade --service-account tiller
 ### Install Weave Flux
 
 The first step in automating Helm releases with [Weave Flux](https://github.com/weaveworks/flux) is to create a Git repository with your charts source code.
-You can fork the [gitops-helm](https://github.com/stefanprodan/gitops-helm) project and use it as a template for your cluster config. 
-** If you fork, update the release definitions with your docker hub repository located in \releases\(dev/stg/prod)\podinfo.yaml in your master branch before proceeding
+You can fork the [gitops-helm](https://github.com/stefanprodan/gitops-helm) project and use it as a template for your cluster config.
+
+*If you fork, update the release definitions with your docker hub repository located in \releases\(dev/stg/prod)\podinfo.yaml in your master branch before proceeding.
 
 Add the Weave Flux chart repo:
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ helm init --skip-refresh --upgrade --service-account tiller
 
 The first step in automating Helm releases with [Weave Flux](https://github.com/weaveworks/flux) is to create a Git repository with your charts source code.
 You can fork the [gitops-helm](https://github.com/stefanprodan/gitops-helm) project and use it as a template for your cluster config.
+(before proceeding, update the release definitions with your docker hub repository located in \releases\(dev/stg/prod)\podinfo.yaml in your master branch)
 
 Add the Weave Flux chart repo:
 

--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ helm init --skip-refresh --upgrade --service-account tiller
 ### Install Weave Flux
 
 The first step in automating Helm releases with [Weave Flux](https://github.com/weaveworks/flux) is to create a Git repository with your charts source code.
-You can fork the [gitops-helm](https://github.com/stefanprodan/gitops-helm) project and use it as a template for your cluster config.
-(before proceeding, update the release definitions with your docker hub repository located in \releases\(dev/stg/prod)\podinfo.yaml in your master branch)
+You can fork the [gitops-helm](https://github.com/stefanprodan/gitops-helm) project and use it as a template for your cluster config. 
+** If you fork, update the release definitions with your docker hub repository located in \releases\(dev/stg/prod)\podinfo.yaml in your master branch before proceeding
 
 Add the Weave Flux chart repo:
 

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The push refers to repository [docker.io/stefanprodan/podinfo]
 
 Inside the *charts* directory there is a podinfo Helm chart. 
 Using this chart I want to create a release in the `dev` namespace with the image I've just published to Docker Hub.
-Instead of editing the `values.yaml` from the chart source I will create a `FluxHelmRelease` definition: 
+Instead of editing the `values.yaml` from the chart source, I create a `FluxHelmRelease` definition (located in /releases/dev/podinfo.yaml): 
 
 ```yaml
 apiVersion: helm.integrations.flux.weave.works/v1alpha2


### PR DESCRIPTION
When following the read me I got stuck because my docker push was not causing a flux update.  This was because I didn't have the correct repo reference in my master branch.  Also didn't realize that the there was already a FluxHelmRelease definition in the repo.